### PR TITLE
Fix scrambles containing redundant moves (like F B' F2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crystalcube",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Happens because when shortening scrambles, we are combining random moves with a solution, and sometimes combining two sequences will result in redundancies
1. adjacent moves that cancel/combine (like R R', L2 L')
2. sequence of 3 parallel moves that cancel/combine (like F B' F2)

After shortening scrambles, we simplify the resulting moves but only the first type of redundancy was removed

This PR implements the second type

Tested thoroughly, the algorithm is fragile and if incorrect, we would be presenting wrong scrambles that don't match the solutions